### PR TITLE
fix(apps-editor-sdk): Removing unused import #6491

### DIFF
--- a/packages/apps-editor-sdk/CHANGELOG.md
+++ b/packages/apps-editor-sdk/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 1.0.1 (2022-05-17)
+
+**Note:** Version bump only for package @screencloud/apps-editor-sdk

--- a/packages/apps-editor-sdk/CHANGELOG.md
+++ b/packages/apps-editor-sdk/CHANGELOG.md
@@ -6,3 +6,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## 1.0.1 (2022-05-17)
 
 **Note:** Version bump only for package @screencloud/apps-editor-sdk
+
+## 1.0.0 (2022-05-17)
+
+### Features
+
+- first public release ([293c16e](https://github.com/screencloud/developer/commit/293c16e890c8e4e9c6b1f9828bba2af4868d9635))

--- a/packages/apps-editor-sdk/package-lock.json
+++ b/packages/apps-editor-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@screencloud/apps-editor-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/apps-editor-sdk/package.json
+++ b/packages/apps-editor-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@screencloud/apps-editor-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vanilla JavaScript SDK for building ScreenCloud apps",
   "keywords": [
     "screencloud",

--- a/packages/apps-editor-sdk/src/messages.ts
+++ b/packages/apps-editor-sdk/src/messages.ts
@@ -1,4 +1,3 @@
-import { AppConfig } from "./../../apps-sdk/src/types";
 import {
   CONNECT,
   CONNECT_SUCCESS,


### PR DESCRIPTION
Ticket: https://github.com/screencloud/apps/issues/6491

- Removing unused import from `apps-sdk` package which caused the build to output the wrong folder structure.