### PR TITLE
fix(apps-editor-sdk): Fixing requestConfigUpdate #6491

### DIFF
--- a/packages/apps-editor-sdk/CHANGELOG.md
+++ b/packages/apps-editor-sdk/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.2](https://github.com/screencloud/developer/compare/@screencloud/apps-editor-sdk@1.0.1...@screencloud/apps-editor-sdk@1.0.2) (2022-05-18)
+
+**Note:** Version bump only for package @screencloud/apps-editor-sdk
+
+
+
+
+
 ## 1.0.1 (2022-05-17)
 
 **Note:** Version bump only for package @screencloud/apps-editor-sdk

--- a/packages/apps-editor-sdk/package-lock.json
+++ b/packages/apps-editor-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@screencloud/apps-editor-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/apps-editor-sdk/package.json
+++ b/packages/apps-editor-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@screencloud/apps-editor-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Vanilla JavaScript SDK for building ScreenCloud apps",
   "keywords": [
     "screencloud",

--- a/packages/apps-editor-sdk/src/index.ts
+++ b/packages/apps-editor-sdk/src/index.ts
@@ -268,8 +268,8 @@ class ScreenCloud<TConfig = AppConfig> {
   private sendMessage = (message: AppMessage): void => {
     if (this.parentOrigin) {
       if (message.type === REQUEST_CONFIG_UPDATE) {
-        // ReferenceId is always 1 for requestConfigUpdate
-        sendMessage(message, this.parentOrigin, 1);
+        // ReferenceId is always 1 for requestConfigUpdate. RequestConfigUpdate uses referenceId instead of type
+        sendMessage(message.payload, this.parentOrigin, 1);
       } else {
         sendMessage(message, this.parentOrigin);
       }

--- a/packages/apps-editor-sdk/src/utils/postMessage.ts
+++ b/packages/apps-editor-sdk/src/utils/postMessage.ts
@@ -1,3 +1,5 @@
+import { AppConfig } from "./../types";
+import { REQUEST_CONFIG_UPDATE } from "./../constants";
 import { LEGACY_PREFIXED_TYPES, LOG_PREFIX } from "../constants";
 import { AppMessage, PlayerMessage } from "../messages";
 
@@ -8,7 +10,7 @@ import { AppMessage, PlayerMessage } from "../messages";
  * Send a postMessage to the player.
  */
 export const sendMessage = (
-  message: AppMessage,
+  message: AppMessage | AppConfig,
   targetOrigin: string,
   referenceId?: number,
   requestId?: number


### PR DESCRIPTION
Ticket: https://github.com/screencloud/apps/issues/6491

- Fixing issue with Save & Preview button not being enabled after changing config. The data being sent through the post message was in the wrong shape. `requestConfigUpdate` uses `referenceId` as the identifier instead of `type` as opposed to other post messages.