### PR TITLE
Added appManagementToken to the AppContext

### DIFF
--- a/packages/apps-editor-sdk/src/constants.ts
+++ b/packages/apps-editor-sdk/src/constants.ts
@@ -33,6 +33,7 @@ export const SAMPLE_INITIALIZE_PAYLOAD: InitializeMessagePayload<AppConfig> = {
     region: "eu",
     timezone: "Europe/London",
     appViewerToken: "",
+    appManagementToken: "",
   },
   orgId: "org-333",
   spaceId: "space-444",

--- a/packages/apps-editor-sdk/src/types.ts
+++ b/packages/apps-editor-sdk/src/types.ts
@@ -29,6 +29,7 @@ interface PayloadAppContext {
   region: region;
   timezone: string;
   appViewerToken: string;
+  appManagementToken?: string;
 }
 
 export interface AppContext extends PayloadAppContext {


### PR DESCRIPTION
Just adding appManagementToken type to the AppContext, the appManagementToken comes in as part of the context from player and is already there as everything on the context is spread to pass to the editor app. So just adding the type should be enough 