### PR TITLE
Fix build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -55,7 +55,7 @@
   "license": "MIT",
   "scripts": {
     "start": "gatsby develop --port 8010",
-    "build": "gatsby build --prefix-paths",
+    "build": "export NODE_OPTIONS=--openssl-legacy-provider; gatsby build --prefix-paths",
     "format": "prettier --write \"src/**/*.{js,jsx,css,json}\"",
     "lint": "eslint --fix \"src/**/*.{js,jsx}\""
   },

--- a/packages/apps-editor-sdk/src/types.ts
+++ b/packages/apps-editor-sdk/src/types.ts
@@ -29,7 +29,7 @@ interface PayloadAppContext {
   region: region;
   timezone: string;
   appViewerToken: string;
-  appManagementToken?: string;
+  appManagementToken: string;
 }
 
 export interface AppContext extends PayloadAppContext {


### PR DESCRIPTION
Build is failing, saying that node 12 is deprecated and running on node 16 by default now, although cant see where we set the node version 🤷 Issue seems to be around Openssl algorithm deprecations - https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported